### PR TITLE
admin paneli renk ayarları ÖNEMLİ

### DIFF
--- a/panel/assets/assets/js/app.js
+++ b/panel/assets/assets/js/app.js
@@ -554,6 +554,18 @@
 // initialize app
 +function($, window) { 'use strict';
 	window.app.init();
+
+// admin paneli renk düzenleme
+// admin paneli şu anda ayarladığımız gibi kalıyor fakat biz bu ayarlama seçeneğini kapatırsak 
+// aşağıdaki kodları aktif hale getirip renkleri buradan ayarlamalıyız...
+/*window.app.menubar.setTheme("light");
+window.app.menubar.applyTheme();
+
+window.app.navbar.setTheme("warning");
+window.app.navbar.applyTheme();
+window.app.saveSettings();
+*/
+
 	window.app.menubar.init();
 	window.app.navbar.init();
 	window.app.customizer.init();


### PR DESCRIPTION
app.js içinde düzenlemeler yaptık ve admin panelinin renklerini javascript kullanarak düzenledik.
normalde renk seçimini sğ tarafta bulunan buton ile düzenleyip o şekilde bıraktığımızda o şekilde kalıyor. fakat kullanıcı bunu bu şekilde istemeyebilir. renk seçimi olması yerine tek bir renk de kalsın ve sağdaki buton olmasın isteyebilir. bu durumda app.js içinde "admin paneli renk düzenleme" şeklinde aratırsak bu isteği karşılamak için ilgili kodları bulabiliriz.